### PR TITLE
Add Google Tag Manager code to download page

### DIFF
--- a/docs/DownloadOffline.html
+++ b/docs/DownloadOffline.html
@@ -23,8 +23,19 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1">
 		<meta name="theme-color" content="#157878">
 		<link rel="stylesheet" href="Downloadstyle.css">
+		<!-- Google Tag Manager -->
+		<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+		new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+		j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+		'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+		})(window,document,'script','dataLayer','GTM-P36GT9F');</script>
+		<!-- End Google Tag Manager -->
 	</head>
 	<body>
+		<!-- Google Tag Manager (noscript) -->
+		<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P36GT9F"
+		height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+		<!-- End Google Tag Manager (noscript) -->
 		<section class="page-header">
 			<h1 class="project-name">Open Actuarial Textbooks</h1>
 			<h2 class="project-tagline">This project provides interactive,
@@ -93,7 +104,6 @@ From this page, you can download static versions of the text.
 
 		</section>
 
-	</body>
 	<!-- Global site tag (gtag.js) - Google Analytics -->
 	<script async src="https://www.googletagmanager.com/gtag/js?id=UA-125587869-1"></script>
 	<script>
@@ -106,5 +116,5 @@ From this page, you can download static versions of the text.
 
 		gtag('config', 'UA-125587869-1');
 	</script>
-
+	</body>
 </html>


### PR DESCRIPTION
Adds support for Google Tag Manager to the page. The gtag code can be removed once Google Tag Manager is verified as working.